### PR TITLE
Add Chromatic setup for Storybook publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "pnpm run test:unit -- --run && pnpm run test:e2e",
     "test:e2e": "playwright test",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build"
+    "storybook:build": "storybook build",
+    "build-storybook": "storybook build"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
@@ -30,6 +31,7 @@
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@tailwindcss/vite": "^4.1.17",
     "@vitest/browser-playwright": "^4.0.10",
+    "chromatic": "^13.3.4",
     "playwright": "^1.56.1",
     "storybook": "^10.1.2",
     "svelte": "^5.43.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.0.10
         version: 4.0.14(playwright@1.57.0)(vite@7.2.4(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.14)
+      chromatic:
+        specifier: ^13.3.4
+        version: 13.3.4
       playwright:
         specifier: ^1.56.1
         version: 1.57.0


### PR DESCRIPTION
## Summary
- add a build-storybook npm script so Chromatic can build Storybook
- add Chromatic dev dependency and refresh the lockfile

## Testing
- pnpm dlx chromatic --project-token=chpt_fdf4bb4a13db023 *(fails: 403 Forbidden authentication)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692abfa6f580832bba97d324c967a944)